### PR TITLE
Add Support for Full URL-Level Blacklist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Test Branch
+
+on:
+  push:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Cache Go Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run Unit Tests
+        run: go test ./internal/...
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Cache Go Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run Integration Tests
+        run: go test ./tests/integration/...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
     <h1>URL Shortener Backend</h1>
     <strong>A simple service for shortening URLs, tracking clicks, and managing domain restrictions.</strong>
@@ -15,6 +14,7 @@
         <a href="#tech-stack">Tech Stack</a> - 
         <a href="#getting-started">Getting Started</a> - 
         <a href="#usage">Usage</a> - 
+        <a href="#cicd-workflow">CI/CD</a> - 
         <a href="#license">License</a>
     </div>
 </div>
@@ -54,223 +54,137 @@ This is an API allowing users to shorten a long URLs and redirect from a short l
 
 ## Getting Started
 
-TODO
+### Prerequisites
+Make sure you have the following installed before running the projec
+
+- Go 1.23.1 or newer version
+- Firebase Project with service account key for local dev
+- Safe Browsing API Key (from Google API Console)
+- Redis (for local caching and rate limiting) or you may use a managed Redis service, such as Redis Cloud, Upstash, Google Cloud Memorystore, etc
+- Docker  (for integration testing and optionally for containerized run)
+- Google Cloud SDK (for manual deploy)
+
+### Installation / Setup
+1. Clone the repository
+
+```bash
+git clone https://github.com/mfmahendr/url-shortener-backend.git
+cd url-shortener-backend
+```
+2. Download dependencies
+
+```bash
+go mod download
+```
+
+3. Build the application (if you want to) 
+
+```bash
+go build -o app ./cmd/app
+```
+
+### Environment Variables
+Environment variables must be configured for both development and production. You can use a .env file for local setup. You can copy the `.env.example` file to `.env` and fill in the required values.
+
+In production, these values should be passed as environment variables via your deployment tool (e.g. GitHub Actions + Cloud Run).
+| Variable Name                  | Description                                                      |
+|-------------------------------|------------------------------------------------------------------|
+| `APP_ENV`                     | Application environment (must be `development` or `production`)       |
+| `PORT`                        | Port number for the HTTP server (default: `8080`)                |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to your Firebase service account key JSON file (**local development only**). In production, use default credentials. |
+| `FIREBASE_PROJECT_ID`         | Your Firebase project ID                                         |
+| `REDIS_ADDR`                  | Redis server address (e.g. `localhost:6379`)                     |
+| `REDIS_PASSWORD`              | Password for Redis instance                                      |
+| `SAFE_BROWSING_API_KEY`       | Google Safe Browsing API key                                     |
+
+### Run the Application
+Locally using Go:
+```bash
+go run ./cmd/app
+```
+
+Or using Docker:
+
+```bash
+docker build -t url-shortener-backend .
+docker run --env-file .env -e APP_ENV=development -p 8080:8080 url-shortener-backend
+```
+
+### Run Tests
+
+**Unit Tests**
+
+```bash
+go test ./internal/...
+```
+
+**Integration Tests**
+
+Requires Docker (used by testcontainers-go):
+
+```bash
+go test ./tests/integration/...
+```
+
+Integration test will automatically spin up containers for Firebase Emulator and Redis.
+
+Setuju. Karena dokumentasi API lengkap sudah dideploy ke GitHub Pages, bagian `## Usage` bisa disederhanakan jadi ringkasan + link eksternal ke Swagger/OpenAPI-nya.
+
+Ganti section `## Usage` dengan ini:
 
 ## Usage
 
-#### Get welcome message
+The API exposes public and authenticated endpoints for creating and managing short URLs, including analytics and blacklist administration.
 
-```http
-GET /
-```
+> Full API docs are available at:
+> **[https://mfmahendr.github.io/url-shortener-backend/](https://mfmahendr.github.io/url-shortener-backend/)**
+> *(Swagger UI served from GitHub Pages, powered by OpenAPI 3.0)*
 
-Returns a welcome message to verify the API is accessible.
+#### Public Endpoints
 
-| Response | Content                                             |
-| -------- | --------------------------------------------------- |
-| `200`    | `{ "message": "Welcome to the URL Shortener API" }` |
-| `500`    | Internal server error                               |
+* `GET /` → Welcome message
+* `GET /health` → Health check
+* `GET /r/{short_id}` → Redirect to the original URL (tracks click)
 
----
+#### Authenticated Endpoints (`Authorization: Bearer <Firebase_JWT>`)
 
-#### Health check
+**URL Management:**
 
-```http
-GET /health
-```
+* `POST /u/shorten` → Create short URL (optional custom ID, support private links)
+* `GET /u/click-count/{short_id}` → Get total clicks
+* `GET /u/analytics/{short_id}` → Get click logs (with pagination + filters)
+* `GET /u/click-count/{short_id}/export` → Export click logs (CSV/JSON)
 
-Checks if the server is up and running.
+**Admin Only:**
 
-| Response | Content                                              |
-| -------- | ---------------------------------------------------- |
-| `200`    | `{ "status": "ok", "message": "Server is running" }` |
-| `500`    | Internal server error                                |
+* `POST /admin/blacklist` → Add domain to blacklist
+* `GET /admin/blacklist` → List all blacklisted domains
+* `DELETE /admin/blacklist/{domain}` → Remove domain from blacklist
 
----
+For all available endpoints, request/response schema, and authorization rules, please refer to the [API documentation](https://mfmahendr.github.io/url-shortener-backend/).
 
-#### Redirect to original URL
 
-```http
-GET /r/{short_id}
-```
+## CI/CD Workflow
 
-Redirects to the original URL. Click tracking is performed.
+This project uses **GitHub Actions** for automated testing, building, and deployment. Here's how the pipeline works:
 
-| Parameter  | Type     | Description                |
-| ---------- | -------- | -------------------------- |
-| `short_id` | `string` | **Required.** Short URL ID |
+* **Trigger:**
+  CI/CD runs on every push to the `main` branch, excluding changes to docs (`.md` files, `docs/`, etc.).
 
-| Response | Description                          |
-| -------- | ------------------------------------ |
-| `302`    | Redirects to the original URL        |
-| `400`    | Bad request                          |
-| `403`    | Access denied (private or forbidden) |
-| `404`    | Short ID not found                   |
-| `500`    | Server error                         |
+* **Test Stage:**
+  Runs unit tests and integration tests.
 
----
+* **Build Stage:**
+  If all tests pass, the app is built into a Docker image and pushed to **Google Artifact Registry**. Authentication is handled using **Workload Identity Federation (WIF)**.
 
-#### Create a shortened URL
+* **Deploy Stage:**
+  The Docker image is deployed to **Google Cloud Run** using the `google-github-actions/deploy-cloudrun` action. Environment variables are injected securely using GitHub Secrets and Repository Variables.
 
-```http
-POST /u/shorten
-```
+* **Cloud Run Config:**
 
-Authenticated endpoint to shorten a URL.
-
-| Body Parameter | Type      | Description                              |
-| -------------- | --------- | ---------------------------------------- |
-| `url`          | `string`  | **Required.** Long URL to shorten        |
-| `custom_id`    | `string`  | Optional custom short ID                 |
-| `is_private`   | `boolean` | Optional flag to mark the URL as private |
-
-| Response | Content                     |
-| -------- | --------------------------- |
-| `200`    | `{ "short_id": "abc123" }`  |
-| `400`    | Invalid input               |
-| `401`    | Unauthorized                |
-| `403`    | Forbidden (e.g. unsafe URL) |
-| `409`    | Custom ID conflict          |
-| `500`    | Server error                |
-
----
-
-#### Get total click count
-
-```http
-GET /u/click-count/{short_id}
-```
-
-Returns total clicks for a shortlink owned by the user.
-
-| Parameter  | Type     | Description                |
-| ---------- | -------- | -------------------------- |
-| `short_id` | `string` | **Required.** Short URL ID |
-
-| Response | Content                                       |
-| -------- | --------------------------------------------- |
-| `200`    | `{ "short_id": "abc123", "click_count": 42 }` |
-| `400`    | Bad request                                   |
-| `401`    | Unauthorized                                  |
-| `403`    | Forbidden                                     |
-| `404`    | Not found                                     |
-| `500`    | Server error                                  |
-
----
-
-#### Export click data
-
-```http
-GET /u/click-count/{short_id}/export
-```
-
-Exports click logs as CSV or JSON.
-
-| Parameter  | Type     | Description                         |
-| ---------- | -------- | ----------------------------------- |
-| `short_id` | `string` | **Required.** Short URL ID          |
-| `format`   | `string` | Optional. `csv` (default) or `json` |
-
-| Response | Content            |
-| -------- | ------------------ |
-| `200`    | CSV or JSON export |
-| `400`    | Bad request        |
-| `401`    | Unauthorized       |
-| `403`    | Forbidden          |
-| `415`    | Unsupported format |
-| `500`    | Server error       |
-
----
-
-#### Get analytics
-
-```http
-GET /u/analytics/{short_id}
-```
-
-Returns click analytics with pagination and filters.
-
-| Parameter    | Type      | Description                           |
-| ------------ | --------- | ------------------------------------- |
-| `short_id`   | `string`  | **Required.** Short URL ID            |
-| `limit`      | `integer` | Max records to return                 |
-| `cursor`     | `string`  | Pagination cursor (RFC3339 timestamp) |
-| `after`      | `string`  | Filter clicks after this datetime     |
-| `before`     | `string`  | Filter clicks before this datetime    |
-| `order_desc` | `boolean` | Sort results in descending order      |
-
-| Response | Content                               |
-| -------- | ------------------------------------- |
-| `200`    | JSON with analytics data and metadata |
-| `400`    | Bad request                           |
-| `401`    | Unauthorized                          |
-| `403`    | Forbidden                             |
-| `404`    | Not found                             |
-| `500`    | Server error                          |
-
----
-
-#### Add domain to blacklist (Admin only)
-
-```http
-POST /admin/blacklist
-```
-
-Adds a domain to the blacklist.
-
-| Body Parameter | Type     | Description                   |
-| -------------- | -------- | ----------------------------- |
-| `domain`       | `string` | **Required.** Domain to block |
-
-| Response | Content                                  |
-| -------- | ---------------------------------------- |
-| `200`    | `{ "status": "added", "domain": "..." }` |
-| `400`    | Invalid input                            |
-| `401`    | Unauthorized                             |
-| `403`    | Forbidden                                |
-| `409`    | Domain already blacklisted               |
-| `500`    | Server error                             |
-
----
-
-#### Get blacklist (Admin only)
-
-```http
-GET /admin/blacklist
-```
-
-Returns all blacklisted domains.
-
-| Response | Content                 |
-| -------- | ----------------------- |
-| `200`    | Array of domain strings |
-| `401`    | Unauthorized            |
-| `403`    | Forbidden               |
-| `500`    | Server error            |
-
----
-
-#### Remove domain from blacklist (Admin only)
-
-```http
-DELETE /admin/blacklist/{domain}
-```
-
-| Parameter | Type     | Description                    |
-| --------- | -------- | ------------------------------ |
-| `domain`  | `string` | **Required.** Domain to remove |
-
-| Response | Content                                    |
-| -------- | ------------------------------------------ |
-| `200`    | `{ "status": "removed", "domain": "..." }` |
-| `400`    | Bad request                                |
-| `401`    | Unauthorized                               |
-| `403`    | Forbidden                                  |
-| `404`    | Not found                                  |
-| `500`    | Server error                               |
-
----
-
+  * Service Name: `app`
+  * Region: defined via `GCP_REGION` variable
+  * Other environment variables is `FIREBASE_PROJECT_ID`, `REDIS_ADDR`, `REDIS_PASSWORD`, `SAFE_BROWSING_API_KEY`, etc.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,19 @@
     </br>
     </br>
     <div align="center">
-        <img src="https://img.shields.io/github/go-mod/go-version/mfmahendr/url-shortener-backend" />
-        <img src="https://img.shields.io/github/license/mfmahendr/url-shortener-backend" />
-        <img src="https://img.shields.io/github/actions/workflow/status/mfmahendr/url-shortener-backend/google-cloudrun-docker.yml?branch=main" />
-        <img src="https://img.shields.io/github/last-commit/mfmahendr/url-shortener-backend" />
+        <span>
+            <img src="https://img.shields.io/github/go-mod/go-version/mfmahendr/url-shortener-backend" alt="Go Version" />
+            <img src="https://img.shields.io/github/license/mfmahendr/url-shortener-backend" alt="License" />
+            <img src="https://img.shields.io/github/last-commit/mfmahendr/url-shortener-backend" alt="Last Commit" />
+            <img src="https://img.shields.io/github/actions/workflow/status/mfmahendr/url-shortener-backend/google-cloudrun-docker.yml?branch=main" alt="CI Status" />
+            <img src="https://img.shields.io/badge/API-live-blue" alt="Live API status" />
+        </span>
     </div>
+    <div align="center">
+        <a href="https://app-533905689825.asia-southeast2.run.app" target="_blank"><strong>🔗 Visit the Live API</strong></a> ・
+        <a href="https://mfmahendr.github.io/url-shortener-backend/" target="_blank"><strong>📝 View Full API Docs</strong></a>
+    </div>
+    </br>
     <div align="center">
         <a href="#features">Features</a> - 
         <a href="#tech-stack">Tech Stack</a> - 
@@ -19,10 +27,9 @@
     </div>
 </div>
 
-
 <br>
 
-This is an API allowing users to shorten a long URLs and redirect from a short link to the original URL. User can also track click count from the short URL created. An admin may manage some domain to be blacklisted. The API is secured using Firebase Authentication and supports both public and authenticated endpoints.
+This is an API allowing users to shorten long URLs and redirect from a short link to the original URL. Users can also track click analytics. Admins may manage blacklisted domains. The API is secured using Firebase Authentication and supports both public and authenticated endpoints.
 
 ## Features
 

--- a/internal/controllers/blacklist.go
+++ b/internal/controllers/blacklist.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mfmahendr/url-shortener-backend/internal/dto"
 )
 
-func (c *URLController) FetchBlacklistedDomains(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	domains, err := c.blacklistManager.ListBlacklistedDomains(r.Context())
+func (c *URLController) FetchBlacklistItems(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	items, err := c.blacklistManager.ListBlacklisted(r.Context())
 	if err != nil {
 		statusCode := mapErrorToStatusCode(err)
 		http.Error(w, "Failed to retrieve blacklist: "+err.Error(), statusCode)
@@ -17,47 +17,70 @@ func (c *URLController) FetchBlacklistedDomains(w http.ResponseWriter, r *http.R
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(domains); err != nil {
-		http.Error(w, "Failed to encode response", 500)
+	if err := json.NewEncoder(w).Encode(items); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return
 	}
 }
 
 func (c *URLController) AddToBlacklist(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	var req dto.BlacklistDomain
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Domain == "" {
-		http.Error(w, "Invalid request", 400)
+	var req dto.BlacklistItemRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Type == "" || req.Value == "" {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
 		return
 	}
-	err := c.blacklistManager.BlacklistDomain(r.Context(), req.Domain)
+
+	var err error
+	switch req.Type {
+	case "domain":
+		err = c.blacklistManager.BlacklistDomain(r.Context(), req.Value)
+	case "url":
+		err = c.blacklistManager.BlacklistURL(r.Context(), req.Value)
+	default:
+		http.Error(w, "Invalid type: must be 'domain' or 'url'", http.StatusBadRequest)
+		return
+	}
+
 	if err != nil {
 		statusCode := mapErrorToStatusCode(err)
-		http.Error(w, "Failed to add domain to blacklist: "+err.Error(), statusCode)
+		http.Error(w, "Failed to add to blacklist: "+err.Error(), statusCode)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	response := map[string]string{"status": "added", "domain": req.Domain}
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		http.Error(w, "Failed to encode response", 500)
-		return
-	}
+	resp := map[string]string{"status": "added", "type": req.Type, "value": req.Value}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func (c *URLController) RemoveFromBlacklist(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	domain := ps.ByName("domain")
-	if domain == "" {
-		http.Error(w, "Missing domain", 400)
+
+func (c *URLController) RemoveFromBlacklist(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	blacklistValue := r.URL.Query().Get("value")
+	blacklistType := r.URL.Query().Get("type")
+
+	if blacklistValue == "" || blacklistType == "" {
+		http.Error(w, "Missing value or type", http.StatusBadRequest)
 		return
 	}
-	err := c.blacklistManager.UnblacklistDomain(r.Context(), domain)
+
+	var err error
+	switch blacklistType {
+	case "domain":
+		err = c.blacklistManager.UnblacklistDomain(r.Context(), blacklistValue)
+	case "url":
+		err = c.blacklistManager.UnblacklistURL(r.Context(), blacklistValue)
+	default:
+		http.Error(w, "Invalid type: must be 'domain' or 'url'", http.StatusBadRequest)
+		return
+	}
+
 	if err != nil {
 		statusCode := mapErrorToStatusCode(err)
-		http.Error(w, "Failed to remove domain to blacklist: "+err.Error(), statusCode)
+		http.Error(w, "Failed to remove from blacklist: "+err.Error(), statusCode)
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/json")
-	response := map[string]string{"status": "removed", "domain": domain}
+	response := map[string]string{"status": "removed", "type": blacklistType, "value": blacklistValue}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, "Failed to encode response", 500)
 		return

--- a/internal/controllers/route.go
+++ b/internal/controllers/route.go
@@ -19,7 +19,7 @@ func (c *URLController) RegisterRoutes(auth mw.AuthMiddleware) {
 	c.Router.GET("/u/analytics/:short_id", c.RateLimiter.Apply(auth.RequireAuth(c.Analytics)))
 
 	// admin
-	c.Router.GET("/admin/blacklist", c.RateLimiter.Apply(auth.RequireAdminAuth(c.FetchBlacklistedDomains)))
+	c.Router.GET("/admin/blacklist", c.RateLimiter.Apply(auth.RequireAdminAuth(c.FetchBlacklistItems)))
 	c.Router.POST("/admin/blacklist", c.RateLimiter.Apply(auth.RequireAdminAuth(c.AddToBlacklist)))
 	c.Router.DELETE("/admin/blacklist", c.RateLimiter.Apply(auth.RequireAdminAuth(c.RemoveFromBlacklist)))
 }

--- a/internal/dto/blacklist_dto.go
+++ b/internal/dto/blacklist_dto.go
@@ -1,5 +1,6 @@
 package dto
 
-type BlacklistDomain struct {
-	Domain    string    `json:"domain,omitempty" validate:"required,hostname"`
+type BlacklistItemRequest struct {
+	Type  string `json:"type"`  // "domain" or "url"
+	Value string `json:"value"`
 }

--- a/internal/models/blacklist_item.go
+++ b/internal/models/blacklist_item.go
@@ -1,0 +1,6 @@
+package models
+
+type BlacklistItem struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}

--- a/internal/services/firestore/blacklist.go
+++ b/internal/services/firestore/blacklist.go
@@ -2,8 +2,12 @@ package firestore_service
 
 import (
 	"context"
+	"log"
+	"net/url"
 	"time"
 
+	"github.com/mfmahendr/url-shortener-backend/internal/models"
+	"github.com/mfmahendr/url-shortener-backend/internal/utils"
 	"github.com/mfmahendr/url-shortener-backend/internal/utils/shortlink_errors"
 	"github.com/mfmahendr/url-shortener-backend/internal/utils/validators"
 	"google.golang.org/api/iterator"
@@ -12,15 +16,17 @@ import (
 )
 
 type (
-	BlacklistManager interface {
-		BlacklistDomain(ctx context.Context, domain string) error
-		UnblacklistDomain(ctx context.Context, domain string) error
-		ListBlacklistedDomains(ctx context.Context) ([]string, error)
+	BlacklistChecker interface {
+		IsBlacklisted(ctx context.Context, url string) (bool, error)
 	}
 
-	BlacklistChecker interface {
-		IsDomainBlacklisted(ctx context.Context, domain string) (bool, error)
-	}
+	BlacklistManager interface {
+		BlacklistDomain(ctx context.Context, domain string) error
+		BlacklistURL(ctx context.Context, inputURL string) error
+		UnblacklistDomain(ctx context.Context, domain string) error
+		UnblacklistURL(ctx context.Context, inputURL string) error
+		ListBlacklisted(ctx context.Context) ([]models.BlacklistItem, error)
+}
 )
 
 // Blacklist manager implementation
@@ -29,21 +35,49 @@ func (s *FirestoreServiceImpl) BlacklistDomain(ctx context.Context, domain strin
 		return shortlink_errors.ErrValidateRequest
 	}
 
-	ok, err := s.isDomainBlacklisted(ctx, domain)
+	exists, err := s.isDomainBlacklisted(ctx, domain)
 	if err != nil {
 		return err
 	}
-	if ok {
+	if exists {
 		return shortlink_errors.ErrResourceExists
 	}
 
-	_, err = s.client.Collection("blacklist_domains").Doc(domain).Set(ctx, map[string]interface{}{
+	_, err = s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(domain)).Set(ctx, map[string]interface{}{
+		"type":       "domain",
+		"value":      domain,
 		"created_at": time.Now(),
 		"source":     "manual",
 	})
 
 	return err
 }
+
+func (s *FirestoreServiceImpl) BlacklistURL(ctx context.Context, inputURL string) error {
+	parsed, err := url.Parse(inputURL)
+	if err != nil || parsed.Host == "" {
+		return shortlink_errors.ErrValidateRequest
+	}
+
+	normalizedURL := normalizeURLForBlacklist(parsed)
+
+	exists, err := s.isURLBlacklisted(ctx, inputURL)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return shortlink_errors.ErrResourceExists
+	}
+
+	_, err = s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(normalizedURL)).Set(ctx, map[string]interface{}{
+		"type":       "url",
+		"value":      normalizedURL,
+		"created_at": time.Now(),
+		"source":     "manual",
+	})
+	return err
+}
+
 
 func (s *FirestoreServiceImpl) UnblacklistDomain(ctx context.Context, domain string) error {
 	if err := validators.Validate.Var(domain, "required,hostname"); err != nil {
@@ -58,36 +92,105 @@ func (s *FirestoreServiceImpl) UnblacklistDomain(ctx context.Context, domain str
 		return shortlink_errors.ErrNotFound
 	}
 
-	_, err = s.client.Collection("blacklist_domains").Doc(domain).Delete(ctx)
+	_, err = s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(domain)).Delete(ctx)
 	return err
 }
 
-func (s *FirestoreServiceImpl) ListBlacklistedDomains(ctx context.Context) ([]string, error) {
-	iter := s.client.Collection("blacklist_domains").Documents(ctx)
-	var list []string
+func (s *FirestoreServiceImpl) UnblacklistURL(ctx context.Context, inputURL string) error {
+	if err := validators.Validate.Var(inputURL, "required,url"); err != nil {
+		return shortlink_errors.ErrValidateRequest
+	}
+	
+	parsed, err := url.Parse(inputURL)
+	if err != nil || parsed.Host == "" {
+		return shortlink_errors.ErrValidateRequest
+	}
+
+	normalizedURL := normalizeURLForBlacklist(parsed)
+
+	doc, err := s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(normalizedURL)).Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return shortlink_errors.ErrNotFound
+		}
+		return shortlink_errors.ErrFailedRetrieveData
+	}
+
+	if !doc.Exists() {
+		return shortlink_errors.ErrNotFound
+	}
+
+	_, err = s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(normalizedURL)).Delete(ctx)
+	return err
+}
+
+func (s *FirestoreServiceImpl) ListBlacklisted(ctx context.Context) ([]models.BlacklistItem, error) {
+	iter := s.client.Collection("blacklist_items").Documents(ctx)
+	var list []models.BlacklistItem
 	for {
 		doc, err := iter.Next()
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
+			log.Println("Unexpected error:", err)
 			return nil, shortlink_errors.ErrFailedRetrieveData
 		}
-		list = append(list, doc.Ref.ID)
+		
+		var item models.BlacklistItem
+		if err := doc.DataTo(&item); err != nil {
+			log.Println("Unexpected error:", err)
+			return nil, shortlink_errors.ErrFailedRetrieveData
+		}
+		list = append(list, item)
 	}
 	return list, nil
 }
 
-func (s *FirestoreServiceImpl) IsDomainBlacklisted(ctx context.Context, domain string) (bool, error) {
-	if err := validators.Validate.Var(domain, "required,hostname"); err != nil {
+func (s *FirestoreServiceImpl) IsBlacklisted(ctx context.Context, inputURL string) (bool, error) {
+	if inputURL == "" {
 		return false, shortlink_errors.ErrValidateRequest
 	}
 
-	return s.isDomainBlacklisted(ctx, domain)
+	parsed, err := url.Parse(inputURL)
+	if err != nil || parsed.Host == "" {
+		if err := validators.Validate.Var(inputURL, "hostname"); err != nil {
+			return false, shortlink_errors.ErrValidateRequest
+		}
+		return s.isDomainBlacklisted(ctx, inputURL)
+	}
+
+	domain := parsed.Hostname()
+
+	isDomainBlacklisted, err := s.isDomainBlacklisted(ctx, domain)
+	if err != nil {
+		return false, err
+	}
+
+	isURLBlacklisted, err := s.isURLBlacklisted(ctx, inputURL)
+	if err != nil {
+		return false, err
+	}
+
+	return isDomainBlacklisted || isURLBlacklisted, nil
 }
 
 func (s *FirestoreServiceImpl) isDomainBlacklisted(ctx context.Context, domain string) (bool, error) {
-	doc, err := s.client.Collection("blacklist_domains").Doc(domain).Get(ctx)
+	doc, err := s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(domain)).Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return false, nil
+		}
+		return false, shortlink_errors.ErrFailedRetrieveData
+	}
+	return doc.Exists(), nil
+}
+
+func (s *FirestoreServiceImpl) isURLBlacklisted(ctx context.Context, inputURL string) (bool, error) {
+	parsed, _ := url.Parse(inputURL)
+	normalizedURL := normalizeURLForBlacklist(parsed)
+	
+	doc, err := s.client.Collection("blacklist_items").Doc(utils.GenerateDocID(normalizedURL)).Get(ctx)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
 			return false, nil

--- a/internal/services/firestore/helper.go
+++ b/internal/services/firestore/helper.go
@@ -3,6 +3,8 @@ package firestore_service
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -57,4 +59,13 @@ func checkDocumentExists(ctx context.Context, q firestore.Query) (bool, error) {
 		return true, fmt.Errorf("failed to check documents: %w", err)
 	}
 	return false, nil
+}
+
+func normalizeURLForBlacklist(u *url.URL) string {
+	host := strings.ToLower(u.Hostname())
+	path := strings.TrimSuffix(u.EscapedPath(), "/")
+	if path == "" {
+		return host
+	}
+	return host + path
 }

--- a/internal/services/url_service/shorten_url.go
+++ b/internal/services/url_service/shorten_url.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log"
 	"net/url"
-	"strings"
 	"time"
 
 	nanoid "github.com/matoous/go-nanoid/v2"
@@ -68,11 +67,10 @@ func (s *URLServiceImpl) validateURL(ctx context.Context, targetURL string) erro
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
-	domain := strings.ToLower(parsedURL.Hostname())
 
 	// check if urls/its domain is blacklisted
 	eg.Go(func() error {
-		isBlacklisted, err := s.blacklist.IsBlacklisted(ctx, domain)
+		isBlacklisted, err := s.blacklist.IsBlacklisted(ctx, targetURL)
 		if err != nil {
 			log.Println("Error while checking blacklisted items:")
 			return err

--- a/internal/services/url_service/shorten_url.go
+++ b/internal/services/url_service/shorten_url.go
@@ -70,16 +70,16 @@ func (s *URLServiceImpl) validateURL(ctx context.Context, targetURL string) erro
 	eg, ctx := errgroup.WithContext(ctx)
 	domain := strings.ToLower(parsedURL.Hostname())
 
-	// check custom blacklisted domain
+	// check if urls/its domain is blacklisted
 	eg.Go(func() error {
-		isBlacklisted, err := s.blacklist.IsDomainBlacklisted(ctx, domain)
+		isBlacklisted, err := s.blacklist.IsBlacklisted(ctx, domain)
 		if err != nil {
-			log.Println("Failed to retrieve data")
-			return shortlink_errors.ErrFailedRetrieveData
+			log.Println("Error while checking blacklisted items:")
+			return err
 		}
 		if isBlacklisted {
-			log.Println("This domain is blacklisted")
-			return shortlink_errors.ErrBlacklistedID
+			log.Println("This URL/domain is blacklisted")
+			return shortlink_errors.ErrForbiddenInput
 		}
 		return nil
 	})

--- a/internal/services/url_service/url_service_test.go
+++ b/internal/services/url_service/url_service_test.go
@@ -34,8 +34,8 @@ func (m *MockShortlink) GetShortlink(ctx context.Context, shortID string) (*mode
 // Firestore blacklist checker SERVICE
 type MockBlacklistChecker struct{ mock.Mock }
 
-func (m *MockBlacklistChecker) IsDomainBlacklisted(ctx context.Context, domain string) (bool, error) {
-	args := m.Called(ctx, domain)
+func (m *MockBlacklistChecker) IsBlacklisted(ctx context.Context, inputURL string) (bool, error) {
+	args := m.Called(ctx, inputURL)
 	return args.Bool(0), args.Error(1)
 }
 

--- a/internal/services/url_service/url_service_test.go
+++ b/internal/services/url_service/url_service_test.go
@@ -169,7 +169,7 @@ func TestShorten_SuccessWithCustomID(t *testing.T) {
 
 		mockBL.On("IsBlacklisted", mock.MatchedBy(func(ctx context.Context) bool {
 			return ctx.Value(utils.UserKey) == "user123"
-		}), "example.com").Return(false, nil) 										// domain is not blacklisted
+		}), req.URL).Return(false, nil) 											// domain is not blacklisted
 		mockSB.On("IsUnsafe", mock.MatchedBy(func(ctx context.Context) bool {
 			return ctx.Value(utils.UserKey) == "user123"
 		}), req.URL).Return(false, nil) 											// domain is safe

--- a/internal/services/url_service/url_service_test.go
+++ b/internal/services/url_service/url_service_test.go
@@ -167,7 +167,7 @@ func TestShorten_SuccessWithCustomID(t *testing.T) {
 			IsPrivate: true,
 		}
 
-		mockBL.On("IsDomainBlacklisted", mock.MatchedBy(func(ctx context.Context) bool {
+		mockBL.On("IsBlacklisted", mock.MatchedBy(func(ctx context.Context) bool {
 			return ctx.Value(utils.UserKey) == "user123"
 		}), "example.com").Return(false, nil) 										// domain is not blacklisted
 		mockSB.On("IsUnsafe", mock.MatchedBy(func(ctx context.Context) bool {

--- a/internal/utils/doc_id_generator.go
+++ b/internal/utils/doc_id_generator.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+    "crypto/sha256"
+    "encoding/base64"
+)
+
+func GenerateDocID(input string) string {
+    hash := sha256.Sum256([]byte(input))
+    return base64.RawURLEncoding.EncodeToString(hash[:])
+}

--- a/tests/integration/blacklist_test.go
+++ b/tests/integration/blacklist_test.go
@@ -26,8 +26,8 @@ func TestBlacklist(t *testing.T) {
 	controller := controllers.New(nil, nil, fsService, nil)
 
 	controller.Router.POST("/admin/blacklist", authMiddleware.RequireAdminAuth(controller.AddToBlacklist))
-	controller.Router.DELETE("/admin/blacklist/:domain", authMiddleware.RequireAdminAuth(controller.RemoveFromBlacklist))
-	controller.Router.GET("/admin/blacklist", authMiddleware.RequireAdminAuth(controller.FetchBlacklistedDomains))
+	controller.Router.DELETE("/admin/blacklist", authMiddleware.RequireAdminAuth(controller.RemoveFromBlacklist))
+	controller.Router.GET("/admin/blacklist", authMiddleware.RequireAdminAuth(controller.FetchBlacklistItems))
 
 	// Create user and set admin user claim
 	claims := map[string]interface{}{
@@ -39,7 +39,7 @@ func TestBlacklist(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Successfully blacklist a valid domain", func(t *testing.T) {
-		body := `{"domain": "assume-this-as-a-valid-domain-to-be-blacklisted.com"}`
+		body := `{"type": "domain", "value": "assume-this-as-a-valid-domain-to-be-blacklisted.com"}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Content-Type", "application/json")
@@ -49,9 +49,25 @@ func TestBlacklist(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Contains(t, rec.Body.String(), `"status":"added"`)
-		assert.Contains(t, rec.Body.String(), `"domain":"assume-this-as-a-valid-domain-to-be-blacklisted.com"`)
+		assert.Contains(t, rec.Body.String(), `"value":"assume-this-as-a-valid-domain-to-be-blacklisted.com"`)
+		assert.Contains(t, rec.Body.String(), `"type":"domain"`)
 	})
-	
+
+	t.Run("Successfully blacklist a URL", func(t *testing.T) {
+		body := `{"type": "url", "value": "https://malicious.com/phishing"}`
+		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"status":"added"`)
+		assert.Contains(t, rec.Body.String(), `"value":"https://malicious.com/phishing"`)
+		assert.Contains(t, rec.Body.String(), `"type":"url"`)
+	})
+
 	t.Run("Failed blacklist a domain by a non-admin user", func(t *testing.T) {
 		body := `{"domain": "assume-this-as-a-different-valid-domain-to-be-blacklisted.com"}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
@@ -60,13 +76,13 @@ func TestBlacklist(t *testing.T) {
 		rec := httptest.NewRecorder()
 
 		controller.Router.ServeHTTP(rec, req)
-		
+
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 		assert.Contains(t, strings.ToLower(rec.Body.String()), "forbidden")
 	})
 
 	t.Run("Failed blacklist an existing domain", func(t *testing.T) {
-		body := `{"domain": "assume-this-as-a-valid-domain-to-be-blacklisted.com"}`
+		body := `{"type": "domain", "value": "assume-this-as-a-valid-domain-to-be-blacklisted.com"}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Content-Type", "application/json")
@@ -79,7 +95,7 @@ func TestBlacklist(t *testing.T) {
 	})
 
 	t.Run("Failed blacklist invalid format domain", func(t *testing.T) {
-		body := `{"domain": "this-is-not-a-valid-domain!!"}`
+		body := `{"type": "domain", "value": "this-is-not-a-valid-domain!!"}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Content-Type", "application/json")
@@ -92,7 +108,7 @@ func TestBlacklist(t *testing.T) {
 	})
 
 	t.Run("Add empty domain", func(t *testing.T) {
-		body := `{"domain": ""}`
+		body := `{"type": "domain", "value": ""}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Content-Type", "application/json")
@@ -116,7 +132,7 @@ func TestBlacklist(t *testing.T) {
 	})
 
 	t.Run("Add without token", func(t *testing.T) {
-		body := `{"domain": "assume-this-as-another-valid-domain-to-be-blacklisted.com"}`
+		body := `{"type": "domain", "value": "assume-this-as-another-valid-domain-to-be-blacklisted.com"}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -130,7 +146,7 @@ func TestBlacklist(t *testing.T) {
 		err := fsService.BlacklistDomain(ctx, "a-domain-to-be-removed.com")
 		require.NoError(t, err)
 
-		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist/a-domain-to-be-removed.com", nil)
+		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist?type=domain&value=a-domain-to-be-removed.com", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 
@@ -138,11 +154,12 @@ func TestBlacklist(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Contains(t, rec.Body.String(), `"status":"removed"`)
-		assert.Contains(t, rec.Body.String(), `"domain":"a-domain-to-be-removed.com"`)
+		assert.Contains(t, rec.Body.String(), `"value":"a-domain-to-be-removed.com"`)
+		assert.Contains(t, rec.Body.String(), `"type":"domain"`)
 	})
 
 	t.Run("Remove non-existent domain", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist/notfound.com", nil)
+		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist?type=domain&value=notfound.com", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 
@@ -153,7 +170,7 @@ func TestBlacklist(t *testing.T) {
 	})
 
 	t.Run("Remove invalid domain format", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist/!!!invalid", nil)
+		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist?type=domain&value=!!!invalid", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 
@@ -177,11 +194,23 @@ func TestBlacklist(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rec.Code)
 
-		var domains []string
-		err = json.Unmarshal(rec.Body.Bytes(), &domains)
+		var items []struct {
+			Type  string `json:"type"`
+			Value string `json:"value"`
+		}
+
+		err = json.Unmarshal(rec.Body.Bytes(), &items)
 		require.NoError(t, err)
-		assert.Contains(t, domains, "a-fetchable-blacklisted-domain.com")
-		assert.Contains(t, domains, "another-fetchable-blacklisted-domain.com")
+
+		values := make([]string, 0)
+		for _, item := range items {
+			if item.Type == "domain" {
+				values = append(values, item.Value)
+			}
+		}
+
+		assert.Contains(t, values, "a-fetchable-blacklisted-domain.com")
+		assert.Contains(t, values, "another-fetchable-blacklisted-domain.com")
 	})
 
 	t.Run("Fetch without token", func(t *testing.T) {

--- a/tests/integration/blacklist_test.go
+++ b/tests/integration/blacklist_test.go
@@ -158,6 +158,20 @@ func TestBlacklist(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), `"type":"domain"`)
 	})
 
+	t.Run("Successfully remove existing URL", func(t *testing.T) {
+		err := fsService.BlacklistURL(ctx, "https://this-is-a-removable-url-to-be-remove.com/some-path/to/anything")
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist?type=url&value=https://this-is-a-removable-url-to-be-remove.com/some-path/to/anything", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"status":"removed"`)
+	})
+
 	t.Run("Remove non-existent domain", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/admin/blacklist?type=domain&value=notfound.com", nil)
 		req.Header.Set("Authorization", "Bearer "+token)

--- a/tests/integration/blacklist_test.go
+++ b/tests/integration/blacklist_test.go
@@ -107,7 +107,7 @@ func TestBlacklist(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), shortlink_errors.ErrValidateRequest.Error())
 	})
 
-	t.Run("Add empty domain", func(t *testing.T) {
+	t.Run("Failed blacklist empty value", func(t *testing.T) {
 		body := `{"type": "domain", "value": ""}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -119,7 +119,7 @@ func TestBlacklist(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
-	t.Run("Add malformed JSON", func(t *testing.T) {
+	t.Run("Failed blacklist malformed JSON", func(t *testing.T) {
 		body := `{`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -131,7 +131,7 @@ func TestBlacklist(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
-	t.Run("Add without token", func(t *testing.T) {
+	t.Run("Blacklist without token", func(t *testing.T) {
 		body := `{"type": "domain", "value": "assume-this-as-another-valid-domain-to-be-blacklisted.com"}`
 		req := httptest.NewRequest(http.MethodPost, "/admin/blacklist", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")

--- a/tests/integration/shorten_test.go
+++ b/tests/integration/shorten_test.go
@@ -224,7 +224,7 @@ func TestShorten(t *testing.T) {
 		controller.Router.ServeHTTP(rec, req)
 
 		assert.Equal(t, http.StatusForbidden, rec.Code)
-		assert.Contains(t, rec.Body.String(), shortlink_errors.ErrBlacklistedID.Error())
+		assert.Contains(t, rec.Body.String(), shortlink_errors.ErrForbiddenInput.Error())
 	})
 
 	t.Run("fail with unsafe domain (safebrowsing)", func(t *testing.T) {


### PR DESCRIPTION
## **Summary**
Added a new feature to be able to blacklist URLs at the path level.

## **Changes**
- Add blacklist item model and update its DTOs
- Add blacklist and unblacklist service for URL (not only domains now)
- Update blacklist checking implementation in shorten service
- Update unit and integration tests

## **Checklist**
- [x] Unit test have been updated
- [x] Every single test goes perfectly well
- [ ] Update documentation (README/Swagger)
- [x] No secrets/tokens/credentials are exposed
