### PR TITLE
feat: ✨ add user's links retrieval functionality with pagination and privaacy filtering

### DIFF
--- a/internal/controllers/analytics.go
+++ b/internal/controllers/analytics.go
@@ -25,14 +25,14 @@ func (c *URLController) Analytics(w http.ResponseWriter, r *http.Request, ps htt
 		return
 	}
 
-	// Parse query params
-	query := &dto.ClickLogsQuery{
+	// Parse req params
+	req := &dto.ClickLogsRequest{
 		ShortID: shortID,
 	}
-	parseClickLogsQuery(r, query)
+	parseClickLogsQuery(r, &req.ClickLogsQuery)
 
 	// Fetch analytics data
-	responseData, err := c.trackingService.GetAnalytics(ctx, *query)
+	responseData, err := c.trackingService.GetAnalytics(ctx, *req)
 	if err != nil {
 		statusCode := mapErrorToStatusCode(err)
 		http.Error(w, "Failed to fetch analytics", statusCode)

--- a/internal/controllers/click_count.go
+++ b/internal/controllers/click_count.go
@@ -63,7 +63,7 @@ func (c *URLController) ExportAllClickCount(w http.ResponseWriter, r *http.Reque
 		format = "csv"
 	}
 	ctx := context.WithValue(r.Context(), utils.ExportFormatKey, format)
-	query := dto.ClickLogsQuery{
+	query := dto.ClickLogsRequest{
 		ShortID: shortID,
 	}
 

--- a/internal/controllers/helper.go
+++ b/internal/controllers/helper.go
@@ -44,6 +44,19 @@ func verifyOwnerAccess(w http.ResponseWriter, err error, isOwner bool) bool {
 }
 
 func parseClickLogsQuery(r *http.Request, query *dto.ClickLogsQuery) {
+	parsePaginationQuery(r, &query.PaginationQuery)
+
+	if after := r.URL.Query().Get("after"); after != "" {
+		t, _ := time.Parse(time.RFC3339, after)
+		query.After = t
+	}
+	if before := r.URL.Query().Get("before"); before != "" {
+		t, _ := time.Parse(time.RFC3339, before)
+		query.Before = t
+	}
+}
+
+func parsePaginationQuery(r *http.Request, query *dto.PaginationQuery) {
 	if l := r.URL.Query().Get("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil {
 			query.Limit = parsed
@@ -54,13 +67,4 @@ func parseClickLogsQuery(r *http.Request, query *dto.ClickLogsQuery) {
 
 	query.Cursor = r.URL.Query().Get("cursor")
 	query.OrderDesc = r.URL.Query().Get("order") == "desc"
-
-	if after := r.URL.Query().Get("after"); after != "" {
-		t, _ := time.Parse(time.RFC3339, after)
-		query.After = t
-	}
-	if before := r.URL.Query().Get("before"); before != "" {
-		t, _ := time.Parse(time.RFC3339, before)
-		query.Before = t
-	}
 }

--- a/internal/controllers/route.go
+++ b/internal/controllers/route.go
@@ -13,6 +13,7 @@ func (c *URLController) RegisterRoutes(auth mw.AuthMiddleware) {
 
 	c.Router.GET("/r/:short_id", c.RateLimiter.Apply(auth.OptionalAuth(c.Redirect)))
 	
+	c.Router.GET("/u/shortlinks", c.RateLimiter.Apply(auth.RequireAuth(c.GetShortlinks)))
 	c.Router.POST("/u/shorten", c.RateLimiter.Apply(auth.RequireAuth(c.Shorten)))
 	c.Router.GET("/u/click-count/:short_id", c.RateLimiter.Apply(auth.RequireAuth(c.GetClickCount)))
 	c.Router.GET("/u/click-count/:short_id/export", c.RateLimiter.Apply(auth.RequireAuth(c.ExportAllClickCount)))

--- a/internal/controllers/shortlinks.go
+++ b/internal/controllers/shortlinks.go
@@ -20,7 +20,7 @@ func (c *URLController) GetShortlinks(w http.ResponseWriter, r *http.Request, _ 
 	// queries
 	var isPrivateQ string
 	paginationQ := new(dto.PaginationQuery)
-	if isPrivateQ = r.URL.Query().Get("is_private"); isPrivateQ != "" {
+	if isPrivateQ = r.URL.Query().Get("is_private"); isPrivateQ == "" {
 		isPrivateQ = "all"
 	}
 	parsePaginationQuery(r, paginationQ)
@@ -40,6 +40,7 @@ func (c *URLController) GetShortlinks(w http.ResponseWriter, r *http.Request, _ 
 		if statusCode != http.StatusNotFound {
 			http.Error(w, "Failed to get users' shortlinks: "+err.Error(), statusCode)
 		}
+		resp = &dto.UserLinksResponse{}
 	}
 	resp.CreatedBy = linksReq.CreatedBy
 

--- a/internal/controllers/shortlinks.go
+++ b/internal/controllers/shortlinks.go
@@ -41,6 +41,7 @@ func (c *URLController) GetShortlinks(w http.ResponseWriter, r *http.Request, _ 
 			http.Error(w, "Failed to get users' shortlinks: "+err.Error(), statusCode)
 		}
 	}
+	resp.CreatedBy = linksReq.CreatedBy
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)

--- a/internal/controllers/shortlinks.go
+++ b/internal/controllers/shortlinks.go
@@ -1,0 +1,47 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/mfmahendr/url-shortener-backend/internal/dto"
+	"github.com/mfmahendr/url-shortener-backend/internal/utils"
+)
+
+func (c *URLController) GetShortlinks(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	createdBy, ok := ctx.Value(utils.UserKey).(string)
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// queries
+	var isPrivateQ string
+	paginationQ := new(dto.PaginationQuery)
+	if isPrivateQ = r.URL.Query().Get("is_private"); isPrivateQ != "" {
+		isPrivateQ = "all"
+	}
+	parsePaginationQuery(r, paginationQ)
+	shortlinksQ := &dto.UserLinksQuery{
+		IsPrivate:       isPrivateQ,
+		PaginationQuery: *paginationQ,
+	}
+
+	linksReq := &dto.UserLinksRequest{
+		CreatedBy:      createdBy,
+		UserLinksQuery: *shortlinksQ,
+	}
+
+	resp, err := c.shortenService.GetUserLinks(ctx, *linksReq)
+	if err != nil {
+		statusCode := mapErrorToStatusCode(err)
+		if statusCode != http.StatusNotFound {
+			http.Error(w, "Failed to get users' shortlinks: "+err.Error(), statusCode)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/dto/analytics_dto.go
+++ b/internal/dto/analytics_dto.go
@@ -16,3 +16,8 @@ type ClickLogDTO struct {
 	IP        string    `json:"ip"`
 	UserAgent string    `json:"user_agent"`
 }
+
+type ClickLogsRequest struct {
+	ShortID   string    `json:"short_id" validate:"required,short_id"`
+	ClickLogsQuery
+}

--- a/internal/dto/query.go
+++ b/internal/dto/query.go
@@ -11,7 +11,6 @@ type PaginationQuery struct {
 }
 
 type ClickLogsQuery struct {
-	ShortID   string    `json:"short_id" validate:"required,short_id"`
 	UserAgent string    `json:"user_agent,omitempty" validate:"omitempty"`
 	After     time.Time `json:"after" validate:"omitempty,datetime"`
 	Before    time.Time `json:"before" validate:"omitempty,datetime"`

--- a/internal/dto/query.go
+++ b/internal/dto/query.go
@@ -10,6 +10,11 @@ type PaginationQuery struct {
 	OrderDesc bool   `json:"order_desc" validate:"-"`
 }
 
+type UserLinksQuery struct {
+	IsPrivate string `json:"is_private" validate:"omitempty,oneof='true' 'yes' 'no' 'false' 'all'"`
+	PaginationQuery
+}
+
 type ClickLogsQuery struct {
 	UserAgent string    `json:"user_agent,omitempty" validate:"omitempty"`
 	After     time.Time `json:"after" validate:"omitempty,datetime"`

--- a/internal/dto/query.go
+++ b/internal/dto/query.go
@@ -11,7 +11,7 @@ type PaginationQuery struct {
 }
 
 type UserLinksQuery struct {
-	IsPrivate string `json:"is_private" validate:"omitempty,oneof='true' 'yes' 'no' 'false' 'all'"`
+	IsPrivate string `json:"is_private" validate:"omitempty,oneof=true yes no false all"`
 	PaginationQuery
 }
 

--- a/internal/dto/shortlinks_dto.go
+++ b/internal/dto/shortlinks_dto.go
@@ -10,6 +10,7 @@ type UserLinksRequest struct {
 type UserLinksResponse struct {
 	Links      []ShortlinkDTO `json:"links"`
 	NextCursor string         `json:"next_cursor"`
+	CreatedBy  string         `json:"created_by"`
 }
 
 type ShortlinkDTO struct {

--- a/internal/dto/shortlinks_dto.go
+++ b/internal/dto/shortlinks_dto.go
@@ -1,0 +1,20 @@
+package dto
+
+import "time"
+
+type UserLinksRequest struct {
+	CreatedBy string `json:"created_by"`
+	UserLinksQuery
+}
+
+type UserLinksResponse struct {
+	Links      []ShortlinkDTO `json:"links"`
+	NextCursor string         `json:"next_cursor"`
+}
+
+type ShortlinkDTO struct {
+	ShortID   string    `json:"short_id"`
+	URL       string    `json:"url"`
+	CreatedAt time.Time `json:"created_at"`
+	IsPrivate bool      `json:"is_private"`
+}

--- a/internal/services/firestore/click.go
+++ b/internal/services/firestore/click.go
@@ -14,7 +14,7 @@ import (
 
 type ClickLog interface {
 	AddClickLog(ctx context.Context, doc *models.ClickLog) error
-	GetClickLogs(ctx context.Context, query dto.ClickLogsQuery) ([]models.ClickLog, string, error)
+	GetClickLogs(ctx context.Context, req dto.ClickLogsRequest) ([]models.ClickLog, string, error)
 	StreamClickLogs(ctx context.Context, shortID string) (*firestore.DocumentIterator, error)
 	GetAnalytics(ctx context.Context, shortID string) (int64, []models.ClickLog, error)
 }
@@ -27,8 +27,8 @@ func (s *FirestoreServiceImpl) AddClickLog(ctx context.Context, doc *models.Clic
 	return nil
 }
 
-func (s *FirestoreServiceImpl) GetClickLogs(ctx context.Context, query dto.ClickLogsQuery) ([]models.ClickLog, string, error) {
-	queryFirestore := s.buildQuery(query)
+func (s *FirestoreServiceImpl) GetClickLogs(ctx context.Context, req dto.ClickLogsRequest) ([]models.ClickLog, string, error) {
+	queryFirestore := s.buildClickLogsQuery(req.ShortID, req.ClickLogsQuery)
 	iter := queryFirestore.Documents(ctx)
 	defer iter.Stop()
 

--- a/internal/services/firestore/helper.go
+++ b/internal/services/firestore/helper.go
@@ -32,6 +32,22 @@ func (s *FirestoreServiceImpl) buildClickLogsQuery(shortID string, clickLogsQuer
 	return query
 }
 
+func (s *FirestoreServiceImpl) buildUserLinksQuery(createdBy string, q dto.UserLinksQuery) (query firestore.Query) {
+	query = s.client.Collection("shortlinks").Where("created_by", "==", createdBy)
+
+	switch q.IsPrivate {
+	case "true", "yes":
+		query = query.Where("is_private", "==", "true")
+	case "false", "no":
+		query = query.Where("is_private", "==", "false")
+	default:
+	}
+
+	query = buildPaginationQuery(q.PaginationQuery, query)
+
+	return query
+}
+
 func buildPaginationQuery(pq dto.PaginationQuery, query firestore.Query) firestore.Query {
 	if pq.OrderDesc {
 		query = query.OrderBy("timestamp", firestore.Desc)

--- a/internal/services/firestore/helper.go
+++ b/internal/services/firestore/helper.go
@@ -15,10 +15,10 @@ import (
 )
 
 
-func (s *FirestoreServiceImpl) buildQuery(clickLogsQuery dto.ClickLogsQuery) (query firestore.Query) {
-	query = s.client.Collection("click_logs").Where("short_id", "==", clickLogsQuery.ShortID)
+func (s *FirestoreServiceImpl) buildClickLogsQuery(shortID string, clickLogsQuery dto.ClickLogsQuery) (query firestore.Query) {
+	query = s.client.Collection("click_logs").Where("short_id", "==", shortID)
 
-	// Filter range waktu
+	// Filter the range of click logs
 	if !clickLogsQuery.After.IsZero() {
 		query = query.Where("timestamp", ">", clickLogsQuery.After)
 	}
@@ -26,27 +26,32 @@ func (s *FirestoreServiceImpl) buildQuery(clickLogsQuery dto.ClickLogsQuery) (qu
 		query = query.Where("timestamp", "<", clickLogsQuery.Before)
 	}
 
-	// Urutan
-	if clickLogsQuery.OrderDesc {
+	// pagination query
+	query = buildPaginationQuery(clickLogsQuery.PaginationQuery, query)
+
+	return query
+}
+
+func buildPaginationQuery(pq dto.PaginationQuery, query firestore.Query) firestore.Query {
+	if pq.OrderDesc {
 		query = query.OrderBy("timestamp", firestore.Desc)
 	} else {
 		query = query.OrderBy("timestamp", firestore.Asc)
 	}
 
 	// Cursor
-	if clickLogsQuery.Cursor != "" {
-		parsedCursor, err := time.Parse(time.RFC3339Nano, clickLogsQuery.Cursor)
+	if pq.Cursor != "" {
+		parsedCursor, err := time.Parse(time.RFC3339Nano, pq.Cursor)
 		if err == nil {
 			query = query.StartAfter(parsedCursor)
 		}
 	}
 
 	// Limit
-	if clickLogsQuery.Limit <= 0 || clickLogsQuery.Limit > 100 {
-		clickLogsQuery.Limit = 50
+	if pq.Limit <= 0 || pq.Limit > 100 {
+		pq.Limit = 50
 	}
-	query = query.Limit(clickLogsQuery.Limit)
-
+	query = query.Limit(pq.Limit)
 	return query
 }
 

--- a/internal/services/firestore/helper.go
+++ b/internal/services/firestore/helper.go
@@ -26,6 +26,12 @@ func (s *FirestoreServiceImpl) buildClickLogsQuery(shortID string, clickLogsQuer
 		query = query.Where("timestamp", "<", clickLogsQuery.Before)
 	}
 
+	if clickLogsQuery.OrderDesc {
+		query = query.OrderBy("timestamp", firestore.Desc)
+	} else {
+		query = query.OrderBy("timestamp", firestore.Asc)
+	}
+
 	// pagination query
 	query = buildPaginationQuery(clickLogsQuery.PaginationQuery, query)
 
@@ -37,10 +43,15 @@ func (s *FirestoreServiceImpl) buildUserLinksQuery(createdBy string, q dto.UserL
 
 	switch q.IsPrivate {
 	case "true", "yes":
-		query = query.Where("is_private", "==", "true")
+		query = query.Where("is_private", "==", true)
 	case "false", "no":
-		query = query.Where("is_private", "==", "false")
-	default:
+		query = query.Where("is_private", "==", false)
+	}
+
+	if q.OrderDesc {
+		query = query.OrderBy("created_at", firestore.Desc)
+	} else {
+		query = query.OrderBy("created_at", firestore.Asc)
 	}
 
 	query = buildPaginationQuery(q.PaginationQuery, query)
@@ -49,12 +60,6 @@ func (s *FirestoreServiceImpl) buildUserLinksQuery(createdBy string, q dto.UserL
 }
 
 func buildPaginationQuery(pq dto.PaginationQuery, query firestore.Query) firestore.Query {
-	if pq.OrderDesc {
-		query = query.OrderBy("timestamp", firestore.Desc)
-	} else {
-		query = query.OrderBy("timestamp", firestore.Asc)
-	}
-
 	// Cursor
 	if pq.Cursor != "" {
 		parsedCursor, err := time.Parse(time.RFC3339Nano, pq.Cursor)

--- a/internal/services/tracking_service/analytics.go
+++ b/internal/services/tracking_service/analytics.go
@@ -2,18 +2,18 @@ package tracking_service
 
 import (
 	"context"
-	
+
 	"github.com/mfmahendr/url-shortener-backend/internal/dto"
 	"github.com/mfmahendr/url-shortener-backend/internal/utils/shortlink_errors"
 	"github.com/mfmahendr/url-shortener-backend/internal/utils/validators"
 )
 
-func (t *TrackingServiceImpl) GetAnalytics(ctx context.Context, query dto.ClickLogsQuery) (*dto.AnalyticsDTO, error) {
-	if err := validators.Validate.Struct(query); err != nil {
+func (t *TrackingServiceImpl) GetAnalytics(ctx context.Context, req dto.ClickLogsRequest) (*dto.AnalyticsDTO, error) {
+	if err := validators.Validate.Struct(req); err != nil {
 		return nil, shortlink_errors.ErrValidateRequest
 	}
 
-	logs, nextCursor, err := t.firestore.GetClickLogs(ctx, query)
+	logs, nextCursor, err := t.firestore.GetClickLogs(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (t *TrackingServiceImpl) GetAnalytics(ctx context.Context, query dto.ClickL
 	}
 
 	responseData := &dto.AnalyticsDTO{
-		ShortID:     query.ShortID,
+		ShortID:     req.ShortID,
 		TotalClicks: count,
 		Clicks:      dtoLogs,
 		NextCursor:  nextCursor,

--- a/internal/services/tracking_service/stream.go
+++ b/internal/services/tracking_service/stream.go
@@ -20,12 +20,12 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func (s *TrackingServiceImpl) StreamClickLogs(ctx context.Context, w http.ResponseWriter, query dto.ClickLogsQuery) error {
-	if err := validators.Validate.Var(query.ShortID, "short_id"); err != nil {
+func (s *TrackingServiceImpl) StreamClickLogs(ctx context.Context, w http.ResponseWriter, req dto.ClickLogsRequest) error {
+	if err := validators.Validate.Var(req.ShortID, "short_id"); err != nil {
 		return shortlink_errors.ErrValidateRequest
 	}
 
-	iter, err := s.firestore.StreamClickLogs(ctx, query.ShortID)
+	iter, err := s.firestore.StreamClickLogs(ctx, req.ShortID)
 	if err != nil {
 		return err
 	}

--- a/internal/services/tracking_service/tracking_service.go
+++ b/internal/services/tracking_service/tracking_service.go
@@ -11,17 +11,16 @@ import (
 
 type (
 	TrackingService interface {
-	GetClickCount(ctx context.Context, shortID string) (int64, error)
-	TrackClick(ctx context.Context, shortID, ip, userAgent string) error
-	StreamClickLogs(ctx context.Context, w http.ResponseWriter, query dto.ClickLogsQuery) error
-	GetAnalytics(ctx context.Context, query dto.ClickLogsQuery) (*dto.AnalyticsDTO, error)
-}
+		GetClickCount(ctx context.Context, shortID string) (int64, error)
+		TrackClick(ctx context.Context, shortID, ip, userAgent string) error
+		StreamClickLogs(ctx context.Context, w http.ResponseWriter, req dto.ClickLogsRequest) error
+		GetAnalytics(ctx context.Context, req dto.ClickLogsRequest) (*dto.AnalyticsDTO, error)
+	}
 
- 
-TrackingServiceImpl struct {
-	firestore firestoreService.ClickLog
-	redis     *redis.Client
-}
+	TrackingServiceImpl struct {
+		firestore firestoreService.ClickLog
+		redis     *redis.Client
+	}
 )
 
 func New(fs firestoreService.ClickLog, redis *redis.Client) TrackingService {

--- a/internal/services/url_service/shorten_url.go
+++ b/internal/services/url_service/shorten_url.go
@@ -119,3 +119,29 @@ func (s *URLServiceImpl) saveShortlink(ctx context.Context, req dto.ShortenReque
 	}
 	return doc.ShortID, nil
 }
+
+func (s *URLServiceImpl) GetUserLinks(ctx context.Context, req dto.UserLinksRequest) (*dto.UserLinksResponse, error) {
+	if err := val.Validate.Struct(req); err != nil {
+		return nil, shortlink_errors.ErrValidateRequest
+	}
+
+	links, nextCursor, err := s.shortlink.ListUserLinks(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	dtoLinks := make([]dto.ShortlinkDTO, 0, len(links))
+	for _, l := range links {
+		dtoLinks = append(dtoLinks, dto.ShortlinkDTO{
+			ShortID:   l.ShortID,
+			URL:       l.URL,
+			CreatedAt: l.CreatedAt,
+			IsPrivate: l.IsPrivate,
+		})
+	}
+
+	return &dto.UserLinksResponse{
+		Links:      dtoLinks,
+		NextCursor: nextCursor,
+	}, nil
+}

--- a/internal/services/url_service/url_service.go
+++ b/internal/services/url_service/url_service.go
@@ -12,6 +12,7 @@ type URLService interface {
 	Shorten(ctx context.Context, req dto.ShortenRequest) (shortID string, err error)
 	Resolve(ctx context.Context, shortID string) (string, error)
 	IsOwner(ctx context.Context, shortID string, uid string) (bool, error)
+	GetUserLinks(ctx context.Context, req dto.UserLinksRequest) (*dto.UserLinksResponse, error)
 }
 
 type URLServiceImpl struct {

--- a/internal/services/url_service/url_service_test.go
+++ b/internal/services/url_service/url_service_test.go
@@ -31,6 +31,11 @@ func (m *MockShortlink) GetShortlink(ctx context.Context, shortID string) (*mode
 	return args.Get(0).(*models.Shortlink), args.Error(1)
 }
 
+func (m *MockShortlink) ListUserLinks(ctx context.Context, req dto.UserLinksRequest) ([]models.Shortlink, string, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).([]models.Shortlink), args.Get(1).(string), args.Error(2)
+}
+
 // Firestore blacklist checker SERVICE
 type MockBlacklistChecker struct{ mock.Mock }
 

--- a/internal/services/url_service/url_service_test.go
+++ b/internal/services/url_service/url_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -174,17 +175,17 @@ func TestShorten_SuccessWithCustomID(t *testing.T) {
 
 		mockBL.On("IsBlacklisted", mock.MatchedBy(func(ctx context.Context) bool {
 			return ctx.Value(utils.UserKey) == "user123"
-		}), req.URL).Return(false, nil) 											// domain is not blacklisted
+		}), req.URL).Return(false, nil) // domain is not blacklisted
 		mockSB.On("IsUnsafe", mock.MatchedBy(func(ctx context.Context) bool {
 			return ctx.Value(utils.UserKey) == "user123"
-		}), req.URL).Return(false, nil) 											// domain is safe
+		}), req.URL).Return(false, nil) // domain is safe
 		mockSL.On("GetShortlink", mock.MatchedBy(func(c context.Context) bool {
 			return c.Value(utils.UserKey) == "user123"
 		}), req.CustomID).Return(&models.Shortlink{}, shortlink_errors.ErrNotFound) // shortlink not already in the database
 
 		mockSL.On("SetShortlink", mock.MatchedBy(func(c context.Context) bool {
 			return c.Value(utils.UserKey) == "user123"
-		}), req.CustomID, mock.Anything).Return(nil) 								// successful set and save the shortlink
+		}), req.CustomID, mock.Anything).Return(nil) // successful set and save the shortlink
 
 		shortID, err := svc.Shorten(ctx, req)
 
@@ -211,4 +212,59 @@ func TestShorten_InvalidURL(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, shortlink_errors.ErrValidateRequest, err)
 	})
+}
+
+func TestListUserLinks(t *testing.T) {
+	mockSL := new(MockShortlink)
+	mockBL := new(MockBlacklistChecker)
+	mockSB := new(MockURLSafetyChecker)
+
+	svc := url_service.New(mockSL, mockBL, mockSB)
+
+	shortlinks1 := []models.Shortlink{
+		{ShortID: "short1", URL: "https://original1.link", CreatedAt: time.Now(), CreatedBy: "user1", IsPrivate: false},
+		{ShortID: "short5", URL: "https://original5.link", CreatedAt: time.Now(), CreatedBy: "user1", IsPrivate: true},
+		{ShortID: "short6", URL: "https://original6.link", CreatedAt: time.Now(), CreatedBy: "user1", IsPrivate: false},
+		{ShortID: "short8", URL: "https://original8.link", CreatedAt: time.Now(), CreatedBy: "user1", IsPrivate: false},
+	}
+	
+	shortlinks2 := []models.Shortlink{
+		{ShortID: "short2", URL: "https://original2.link", CreatedAt: time.Now(), CreatedBy: "user2", IsPrivate: false},
+		{ShortID: "short3", URL: "https://original3.link", CreatedAt: time.Now(), CreatedBy: "user2", IsPrivate: true},
+		{ShortID: "short4", URL: "https://original4.link", CreatedAt: time.Now(), CreatedBy: "user2", IsPrivate: false},
+		{ShortID: "short7", URL: "https://original7.link", CreatedAt: time.Now(), CreatedBy: "user2", IsPrivate: true},
+		{ShortID: "short9", URL: "https://original9.link", CreatedAt: time.Now(), CreatedBy: "user2", IsPrivate: true},
+		{ShortID: "short10", URL: "https://original10.link", CreatedAt: time.Now(), CreatedBy: "user2", IsPrivate: true},
+	}
+	mockSL.On("ListUserLinks", mock.Anything, mock.MatchedBy(func(r dto.UserLinksRequest) bool {
+		return r.CreatedBy == "user1"
+	})).Return(shortlinks1, "cursor_user1", nil)
+
+	mockSL.On("ListUserLinks", mock.Anything, mock.MatchedBy(func(r dto.UserLinksRequest) bool {
+		return r.CreatedBy == "user2"
+	})).Return(shortlinks2, "cursor_user2", nil)
+
+	t.Run("Should return links for user1", func(t *testing.T) {
+		req := dto.UserLinksRequest{CreatedBy: "user1"}
+		resp, err := svc.GetUserLinks(context.Background(), req)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "cursor_user1", resp.NextCursor)
+		assert.Len(t, resp.Links, len(shortlinks1))
+		assert.Equal(t, shortlinks1[0].ShortID, resp.Links[0].ShortID)
+	})
+
+	t.Run("Should return links for user2", func(t *testing.T) {
+		req := dto.UserLinksRequest{CreatedBy: "user2"}
+		resp, err := svc.GetUserLinks(context.Background(), req)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "cursor_user2", resp.NextCursor)
+		assert.Len(t, resp.Links, len(shortlinks2))
+		assert.Equal(t, shortlinks2[0].ShortID, resp.Links[0].ShortID)
+	})
+
+	mockSL.AssertExpectations(t)
 }

--- a/tests/integration/shortlinks_test.go
+++ b/tests/integration/shortlinks_test.go
@@ -1,0 +1,199 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mfmahendr/url-shortener-backend/internal/controllers"
+	"github.com/mfmahendr/url-shortener-backend/internal/dto"
+	"github.com/mfmahendr/url-shortener-backend/internal/middleware"
+	"github.com/mfmahendr/url-shortener-backend/internal/models"
+	"github.com/mfmahendr/url-shortener-backend/internal/services/url_service"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserLinks(t *testing.T) {
+	ctx := context.Background()
+	tcEnv = GetSharedTestContainerEnv(ctx, t)
+	require.NotNil(t, tcEnv, "tcEnv should be initialized")
+
+	urlSvc := url_service.New(fsService, nil, nil)
+
+	// Middleware
+	authMiddleware := middleware.NewAuthMiddleware(tcEnv.FsApp)
+
+	// Controller
+	controller := controllers.New(urlSvc, nil, fsService, nil)
+	controller.Router.GET("/u/shortlinks", authMiddleware.RequireAuth(controller.GetShortlinks))
+
+	// Create test user and token
+	userID, token, err := createTestUserAndToken(ctx, authMiddleware.AuthClient, "getusershortlinks.user@example.com", nil)
+	require.NoError(t, err)
+
+	// Buat beberapa shortlink untuk user
+	shortlinkData := []struct {
+		ID        string
+		URL       string
+		IsPrivate bool
+	}{
+		{"u1_pub", "https://public1.example.com", false},
+		{"u1_prv", "https://private1.example.com", true},
+		{"u1_pub2", "https://public2.example.com", false},
+	}
+
+	createdByNow := time.Now()
+
+	expectedCorrectUserLinksAmout := 0
+	for _, s := range shortlinkData {
+		err := fsService.SetShortlink(ctx, s.ID, models.Shortlink{
+			ShortID:   s.ID,
+			URL:       s.URL,
+			IsPrivate: s.IsPrivate,
+			CreatedBy: userID,
+			CreatedAt: createdByNow,
+		})
+		createdByNow = createdByNow.Add(time.Second)
+		require.NoError(t, err)
+		expectedCorrectUserLinksAmout++
+	}
+
+	// other shortlink created by other.user@example.com to ascertain filtering
+	otherUserID, _, err := createTestUserAndToken(ctx, authMiddleware.AuthClient, "other.user@example.com", nil)
+	require.NoError(t, err)
+	err = fsService.SetShortlink(ctx, "other_pub", models.Shortlink{
+		ShortID:   "other_pub",
+		URL:       "https://otheruser.link",
+		CreatedAt: createdByNow.Add(time.Second),
+		CreatedBy: otherUserID,
+		IsPrivate: false,
+	})
+	require.NoError(t, err)
+
+	// ---- TEST CASES ----
+	t.Run("success get all user links (default all)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UserLinksResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, userID, resp.CreatedBy)
+		assert.Equal(t, len(resp.Links), expectedCorrectUserLinksAmout)
+		for _, l := range resp.Links {
+			assert.NotEqual(t, "other_pub", l.ShortID)
+		}
+	})
+
+	t.Run("success get only private links", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks?is_private=true", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UserLinksResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, userID, resp.CreatedBy)
+		assert.NotEmpty(t, resp.Links)
+		for _, l := range resp.Links {
+			assert.True(t, l.IsPrivate)
+			assert.NotEqual(t, "other_pub", l.ShortID)
+		}
+	})
+
+	t.Run("success get only public links", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks?is_private=false", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UserLinksResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Links)
+		for _, l := range resp.Links {
+			assert.False(t, l.IsPrivate)
+			assert.NotEqual(t, "other_pub", l.ShortID)
+		}
+	})
+
+	t.Run("pagination works with limit", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks?limit=1", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UserLinksResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Len(t, resp.Links, 1)
+		assert.NotEmpty(t, resp.NextCursor)
+	})
+
+	t.Run("fail without token (unauthorized)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks", nil)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("fail with invalid token (unauthorized)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks", nil)
+		req.Header.Set("Authorization", "Bearer invalid_token_here")
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("empty response if user has no links", func(t *testing.T) {
+		newUserID, newToken, err := createTestUserAndToken(ctx, authMiddleware.AuthClient, "emptyuser@example.com", nil)
+		require.NoError(t, err)
+		_ = newUserID // not needed explicitly here
+
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks", nil)
+		req.Header.Set("Authorization", "Bearer "+newToken)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp dto.UserLinksResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Links)
+	})
+
+	t.Run("invalid query parameter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/u/shortlinks?is_private=notvalid", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+
+		controller.Router.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}


### PR DESCRIPTION
### Summary
This PR introduces the complete functionality for obtaining shortlinks that has been created by the individual, including support for pagination and filtering (based on privacy field). The feature facilitates a new API endpoint `/api/shortlinks` for authenticated users to fetch their subsisted shortlinks.

### Changes
- Added `GetShortlinks` handler in controller, integrated its logic in `shortenService` and Firestore service layer.
- Added **unit tests** for GetUserLinks in URL service and added **integration tests** covering blow test cases:

  - Default retrieval of all links.
  - Filtering by is_private (private / public).
  - Pagination with limit and cursor.
  - Empty result handling.
  - Unauthorized request scenarios.
  
 - Refactors and fixes:
   - Moved `ShortID `field handling in click logs query (cleanup).
   - Fixed Firestore `is_private `query to correctly use boolean values.
   - Adjusted DTO and test data to align with updated schema.
   - Minor validation tag correction in `UserLinkQuery`.

### Testing

- [x] Unit tests passing
- [x] Run integration tests: all passed
- [x] All existing tests still pass